### PR TITLE
fix: 修复remove函数传参isDestroy无效问题

### DIFF
--- a/assets/core/gui/layer/LayerUI.ts
+++ b/assets/core/gui/layer/LayerUI.ts
@@ -116,13 +116,9 @@ export class LayerUI extends Node {
         // 界面移出舞台
         var vp = this.ui_nodes.get(prefabPath);
         if (vp) {
-            // 优先使用参数中控制的释放条件，如果未传递参数则用配置中的释放条件
-            if (release === undefined && vp.config.destroy !== undefined) {
-                release = vp.config.destroy;
-            }
-            // 默认不缓存关闭的界面
-            else {
-                release = true;
+            // 优先使用参数中控制的释放条件，如果未传递参数则用配置中的释放条件，默认不缓存关闭的界面
+            if (release === undefined) {
+                release = vp.config.destroy !== undefined ? vp.config.destroy : true;
             }
 
             // 不释放界面，缓存起来待下次使用


### PR DESCRIPTION
问题：当参数 isDestroy 传入 false 时，release 赋值为 false，执行到 if 判断 release === undefined 后，会走到 else 将 release 重新赋值为 true，导致原先传入的 isDestroy 为 false 失效
```javascript
remove(prefabPath: string, isDestroy?: boolean): void {
    var release = undefined;
    if (isDestroy !== undefined) release = isDestroy;

......

// 优先使用参数中控制的释放条件，如果未传递参数则用配置中的释放条件
if (release === undefined && vp.config.destroy !== undefined) {
    release = vp.config.destroy;
}
// 默认不缓存关闭的界面
else {
    release = true;
}
```


if 逻辑修改为：
```javascript
// 优先使用参数中控制的释放条件，如果未传递参数则用配置中的释放条件，默认不缓存关闭的界面
if (release === undefined) {
    release = vp.config.destroy !== undefined ? vp.config.destroy : true;
}
```